### PR TITLE
Optional password + user and owner for password

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ qpdf.encrypt(localFilePath, options);
 The following are **required options**
 * `keyLength:` - a number which defines the encryption algorithm to be used. Values can be **40, 128 and 256** only.
 * `password:` - a string containing the secret password which will be further used to unlock the PDF.
+* `password:` - an object containing `user` and `owner` for set password for different roles.
 
 You might want to set other options for each encryption algorithm inside `restrictions:` JSON according to the `keyLength` you choose :-
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ qpdf.encrypt(localFilePath, options);
 ### Options for Encryption
 The following are **required options**
 * `keyLength:` - a number which defines the encryption algorithm to be used. Values can be **40, 128 and 256** only.
-* `password:` - a string containing the secret password which will be further used to unlock the PDF.
-* `password:` - an object containing `user` and `owner` for set password for different roles.
+* `password:` - a string containing the secret password which will be further used to unlock the PDF or an object containing `user` and `owner` for setting password for different roles.
 
 You might want to set other options for each encryption algorithm inside `restrictions:` JSON according to the `keyLength` you choose :-
 
@@ -81,6 +80,25 @@ var options = {
 
 qpdf.encrypt(localFilePath, options, outputFilePath);
 ```
+or
+```
+var qpdf = require('node-qpdf');
+
+var options = {
+  keyLength: 40,
+  password: {
+    user: 'YOUR_PASSWORD_TO_ENCRYPT_FOR_USER',
+    owner: 'YOUR_PASSWORD_TO_ENCRYPT_FOR_OWNER'
+  },
+  restrictions: {
+    print: 'low',
+    useAes: 'y'
+  }
+};
+
+qpdf.encrypt(localFilePath, options, outputFilePath);
+```
+
 #### Render and Stream:
 ```
 var qpdf = require('node-qpdf');

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var Qpdf = {};
 
 Qpdf.encrypt = function(input, options, callback) {
   if (!input) return handleError(new Error('Specify input file'));
-  if (!options || !options.password) return handleError(new Error('Password missing'));
   if(options && options.outputFile) {
     if(typeof options.outputFile != 'string' || options.outputFile === input) {
       return handleError(new Error('Invlaid output file'));
@@ -18,8 +17,16 @@ Qpdf.encrypt = function(input, options, callback) {
   var args = [Qpdf.command, '--encrypt'];
 
   // Push twice for user-password and owner-password
-  args.push(options.password);
-  args.push(options.password);
+  if(typeof options.password === 'object') {
+    if(options.password.user === undefined || options.password.owner === undefined) {
+      return handleError(new Error('Specify owner and user password'));
+    }
+    args.push(options.password.user);
+    args.push(options.password.owner);
+  } else {
+    args.push(options.password);
+    args.push(options.password);
+  }
 
   // Specifying the key length
   args.push(options.keyLength);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ Qpdf.encrypt = function(input, options, callback) {
 
   var args = [Qpdf.command, '--encrypt'];
 
-  // Push twice for user-password and owner-password
+  // Set user-password and owner-password
   if(typeof options.password === 'object') {
     if(options.password.user === undefined || options.password.owner === undefined) {
       return handleError(new Error('Specify owner and user password'));
@@ -24,6 +24,7 @@ Qpdf.encrypt = function(input, options, callback) {
     args.push(options.password.user);
     args.push(options.password.owner);
   } else {
+    // Push twice for user-password and owner-password
     args.push(options.password);
     args.push(options.password);
   }


### PR DESCRIPTION
Hi !

According to documentation (http://qpdf.sourceforge.net/files/qpdf-manual.html#ref.encryption-options)

`Either or both of the user password and the owner password may be empty strings.`

And I put possibility to set `user-password` and `owner-password`.

For my use case I need to disable copying and editing but every body can see my PDF. 

```javascript
var options = {
  keyLength: 40,
  password: {
    user: '',
    owner: 'MY_PASSWORD'
  },
  restrictions: {
    print: 'n',
    extract: 'n',
    modify: 'n',
  }
};
`
`
`

User can see PDF and if he has password he can modify or copy.