### PR TITLE
QPDF warn causes process to kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,24 @@ var qpdf = require('node-qpdf');
 
 var options = {
     keyLength: 128,
-    password: 'YOUR_PASSWORD_TO_ENCRYPT'
+    password: 'YOUR_PASSWORD_TO_ENCRYPT',
+    outputFile: 'filename.pdf'
 }
 
-qpdf.encrypt(localFilePath, options);
+qpdf.encrypt(localFilePath, options, callback);
 ```
+
+## Callbacks
+Node-pdf supports both callbacks and promises
+```
+qpdf.encrypt(localFilePath, options, callback);
+```
+AND
+
+```
+await qpdf.encrypt(localFilePath, options);
+```
+
 
 ### Options for Encryption
 The following are **required options**
@@ -78,7 +91,7 @@ var options = {
     }
 }
 
-qpdf.encrypt(localFilePath, options, outputFilePath);
+qpdf.encrypt(localFilePath, options, callback);
 ```
 or
 ```
@@ -96,7 +109,7 @@ var options = {
   }
 };
 
-qpdf.encrypt(localFilePath, options, outputFilePath);
+qpdf.encrypt(localFilePath, options, callback);
 ```
 
 #### Render and Stream:
@@ -112,7 +125,7 @@ var options = {
     }
 }
 
-var doc = qpdf.encrypt(localFilePath, options, outputFilePath);
+var doc = qpdf.encrypt(localFilePath, options);
 
 doc.stdout.pipe(res);
 
@@ -136,13 +149,13 @@ qpdf.decrypt(localFilePath, 'YOUR_PASSWORD_TO_DECRYPT_PDF');
 ```
 var qpdf = require('node-qpdf');
 
-qpdf.decrypt(localFilePath, 'YOUR_PASSWORD_TO_DECRYPT_PDF', outputFilePath);
+qpdf.decrypt(localFilePath, 'YOUR_PASSWORD_TO_DECRYPT_PDF', callback);
 ```
 #### Render and Stream:
 ```
 var qpdf = require('node-qpdf');
 
-var doc = qpdf.decrypt(localFilePath, 'YOUR_PASSWORD_TO_DECRYPT_PDF', outputFilePath);
+var doc = qpdf.decrypt(localFilePath, 'YOUR_PASSWORD_TO_DECRYPT_PDF', callback);
 
 doc.stdout.pipe(res);
 

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var Qpdf = {};
 
 Qpdf.encrypt = function(input, options, callback) {
   if (!input) return handleError(new Error('Specify input file'));
-  if(options && options.outputFile) {
-    if(typeof options.outputFile != 'string' || options.outputFile === input) {
-      return handleError(new Error('Invlaid output file'));
+  if (options && options.outputFile) {
+    if (typeof options.outputFile != 'string' || options.outputFile === input) {
+      return handleError(new Error('Invalid output file'));
     }
   }
 
@@ -17,8 +17,8 @@ Qpdf.encrypt = function(input, options, callback) {
   var args = [Qpdf.command, '--encrypt'];
 
   // Set user-password and owner-password
-  if(typeof options.password === 'object') {
-    if(options.password.user === undefined || options.password.owner === undefined) {
+  if (typeof options.password === 'object') {
+    if (options.password.user === undefined || options.password.owner === undefined) {
       return handleError(new Error('Specify owner and user password'));
     }
     args.push(options.password.user);
@@ -32,13 +32,13 @@ Qpdf.encrypt = function(input, options, callback) {
   // Specifying the key length
   args.push(options.keyLength);
 
-  // Add Resctrictions for encryption
+  // Add Restrictions for encryption
   if (options.restrictions) {
     if (typeof options.restrictions !== 'object') return handleError(new Error('Invalid Restrictions'));
 
     var restrictions = options.restrictions;
 
-    for(var restriction in restrictions) {
+    for (var restriction in restrictions) {
       var value = (restrictions[restriction] !== '') ? '=' + restrictions[restriction] : '';
       args.push('--' + hyphenate(restriction) + value);
     }
@@ -56,6 +56,7 @@ Qpdf.encrypt = function(input, options, callback) {
   // Print PDF on stdout
     args.push('-');
   }
+
   // Execute command and return stdout for pipe
   if (!options.outputFile) {
     var outputStream = executeCommand(args);
@@ -84,8 +85,8 @@ Qpdf.encrypt = function(input, options, callback) {
 };
 
 Qpdf.decrypt = function(input, password, callback) {
-  if (!input) return handleError(new Error('Specify input file'), callback);
-  if (!password) return handleError(new Error('Password missing'), callback);
+  if (!input) return handleError(new Error('Specify input file'), null, callback);
+  if (!password) return handleError(new Error('Password missing'), null, callback);
 
   var args = [Qpdf.command, '--decrypt'];
 
@@ -126,24 +127,17 @@ function executeCommand(args, callback) {
   var outputStream = child.stdout;
 
   child.once('error', function (err) {
-    handleError(err, child, outputStream, callback);
+    handleError(err, outputStream, callback);
   });
   child.stderr.once('data', function(err) {
-    handleError(new Error(err || ''), child, outputStream, callback);
+    handleError(new Error(err || ''), outputStream, callback);
   });
 
   // return stdout stream so we can pipe
   return outputStream;
 }
 
-function handleError(err, child, outputStream, callback) {
-  if (child) {
-    child.removeAllListeners('exit');
-    child.kill();
-  } else if (typeof child === 'function') {
-    callback = child;
-  }
-
+function handleError(err, outputStream, callback) {
   // call the callback if there is one
   if (callback) {
     callback(err);

--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ function executeCommand(args, callback) {
   child.once('error', function (err) {
     handleError(err, outputStream, callback);
   });
+
   child.stderr.once('data', function(err) {
     handleError(new Error(err || ''), outputStream, callback);
   });
@@ -138,10 +139,11 @@ function executeCommand(args, callback) {
 }
 
 function handleError(err, outputStream, callback) {
+  /*This cauces callback to be called twice (once on error, once on exit) */
   // call the callback if there is one
-  if (callback) {
-    callback(err);
-  }
+  // if (callback) {
+  //   callback(err);
+  // }
 
   // set a default output stream if not present
   if (typeof outputStream === 'function') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-qpdf",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Content Preserving transformations on PDFs wrapped around QPDF",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There are cases when QPDF issues warnings about PDFs such as:
> WARNING: filename.pdf: extraneous whitespace seen before xref

Per the current implementation, `child.stderr` handles these warnings and the whole process fails per:
```
    child.removeAllListeners('exit');
    child.kill();
```
The new PDF is never generated even though QPDF is able to handle these errors and generate the PDF without a problem. This PR addresses this issue by removing the ejection code which should allow for users of `node-qpdf` to handle errors within their callback.

This PR also updates the DOCS and lints some styling for consistency